### PR TITLE
fix bug of macvim-askpass

### DIFF
--- a/src/MacVim/macvim-askpass
+++ b/src/MacVim/macvim-askpass
@@ -18,12 +18,12 @@ TITLE=${MACOS_ASKPASS_TITLE:-"SSH"}
 DIALOG="display dialog \"$@\" default answer \"\" with title \"$TITLE\""
 DIALOG="$DIALOG with icon caution with hidden answer"
 
-result=`osascript -e 'tell application "Finder"' -e "activate"  -e "$DIALOG" -e 'end tell'`
+result=`osascript -e 'tell application "Finder"' -e "activate"  -e "$DIALOG" -e "text returned of result" -e 'end tell'`
 osascript -e 'tell application "MacVim"' -e "activate" -e 'end tell'
 
 if [ "$result" = "" ]; then
     exit 1
 else
-    echo "$result" | sed -e 's/^text returned://' -e 's/, button returned:.*$//'
+    echo "$result"
     exit 0
 fi


### PR DESCRIPTION
パスワードを入力した後の戻り値が、変わっており、sedで抜き取っている部分がうまく行ってませんでした。

```
-e "text returned of result"
```

を使うと、パスワード部分のみを取得できるので修正しました。
